### PR TITLE
fix(theme-toggle): sync theme across tabs on storage event

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -32,12 +32,22 @@ function applyTheme(theme: ThemeMode) {
 }
 
 function subscribeToTheme(onStoreChange: () => void) {
+  function handleStorage(event: StorageEvent) {
+    if (event.key !== THEME_STORAGE_KEY) return;
+    const nextTheme: ThemeMode | null =
+      event.newValue === "dark" ? "dark" : event.newValue === "light" ? "light" : null;
+    if (nextTheme === null) return;
+    if (readCurrentTheme() !== nextTheme) {
+      applyTheme(nextTheme);
+    }
+    onStoreChange();
+  }
   window.addEventListener(THEME_CHANGE_EVENT, onStoreChange);
-  window.addEventListener("storage", onStoreChange);
+  window.addEventListener("storage", handleStorage);
 
   return () => {
     window.removeEventListener(THEME_CHANGE_EVENT, onStoreChange);
-    window.removeEventListener("storage", onStoreChange);
+    window.removeEventListener("storage", handleStorage);
   };
 }
 


### PR DESCRIPTION
## Summary

`ThemeToggle`'s `storage` event handler previously just called `onStoreChange`, which made `useSyncExternalStore` re-read the DOM. But the DOM was never modified by another tab — a `storage` event means a peer tab wrote to `localStorage`, while this tab's DOM state was unchanged, so cross-tab theme switches were silently dropped.

Fix: filter `storage` events by `THEME_STORAGE_KEY`, parse the target theme from `event.newValue`, call `applyTheme` to sync this tab's `dataset.theme` / `style.colorScheme` to that value, then trigger `onStoreChange` so `useSyncExternalStore` re-renders. Unknown or missing `newValue` is ignored; events for other storage keys are untouched; `removeEventListener` uses the same stable handler reference so no listener leaks.

Admin pages do not render `ThemeToggle` (`SiteHeader` is not mounted under `src/app/admin/`), so this handler never fires in an admin tab and does not conflict with the initial-paint script's forced-light policy on \`/admin\`.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes (1 pre-existing unrelated warning)
- [x] \`npm test\` passes
- [x] \`npm run build\` passes
- [x] Manual: open two non-admin tabs, toggle theme in one, other tab mirrors immediately (both dark→light and light→dark)